### PR TITLE
require just aws-sdk-ec2 instead of complete aws-sdk resources

### DIFF
--- a/cap-ec2.gemspec
+++ b/cap-ec2.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "aws-sdk", ">= 2.0"
+  spec.add_dependency 'aws-sdk-ec2'
   spec.add_dependency "capistrano", ">= 3.0"
   spec.add_dependency "terminal-table"
   spec.add_dependency "colorize"

--- a/lib/cap-ec2/capistrano.rb
+++ b/lib/cap-ec2/capistrano.rb
@@ -1,5 +1,5 @@
 require 'capistrano/configuration'
-require 'aws-sdk'
+require 'aws-sdk-ec2'
 require 'colorize'
 require 'terminal-table'
 require 'yaml'

--- a/lib/cap-ec2/ec2-handler.rb
+++ b/lib/cap-ec2/ec2-handler.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-ec2'
 
 module CapEC2
   class EC2Handler

--- a/lib/cap-ec2/utils.rb
+++ b/lib/cap-ec2/utils.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-ec2'
 
 module CapEC2
   module Utils


### PR DESCRIPTION
https://github.com/forward3d/cap-ec2/pull/87